### PR TITLE
The emoji set supported by emojify differs from markdown-it-emoji's

### DIFF
--- a/app/components/SmartEditor/SmartEditor.jsx
+++ b/app/components/SmartEditor/SmartEditor.jsx
@@ -172,7 +172,7 @@ const SmartEditor = React.createClass({
     let text = textarea.value, triggerPos = -1;
     for (let i = textarea.selectionEnd - 1; i >= 0; i--) {
       let ch = text.charAt(i);
-      if (/[\w\.-]/.test(ch)) {
+      if (/[^\s@#:]/.test(ch)) {
         continue;
       } else if (["@", "#", ":"].includes(ch)) {
         if (i === 0 || /\s/.test(text.charAt(i - 1))) triggerPos = i;
@@ -202,7 +202,7 @@ const SmartEditor = React.createClass({
   },
 
   _inputKeyDown(e){
-    if(!this.refs.popup.isShow()){
+    if (!this.refs.popup.isShow() && this.props.onKeyDown) {
       this.props.onKeyDown(e);
     }
   },

--- a/app/components/SmartEditor/markdown/index.js
+++ b/app/components/SmartEditor/markdown/index.js
@@ -50,6 +50,13 @@ function commandPlugin(state) {
     });
 }
 
+let emojifyDefs = {};
+EmojiPng.keys().map(k => {
+    let n = k.substr("./".length, k.length - "./.png".length);
+    // If `md.renderer.rules.emoji` is not defined, we need to assign the
+    // unicode of emoji to `emojifyDefs[n]`.
+    emojifyDefs[n] = n;
+});
 
 let md = MarkdownIt({
     highlight(str, lang) {
@@ -65,14 +72,13 @@ let md = MarkdownIt({
     md.inline.ruler.before("text", "at", atPlugin);
 }).use(md => {
     md.inline.ruler.before("text", "command", commandPlugin);
-}).use(Emoji);
+}).use(Emoji, {defs: emojifyDefs});
 
 md.renderer.rules.emoji = (token, i) => {
     let markup = token[i].markup;
     if (EmojiPng.keys().includes("./" + markup + ".png")) {
-        return '<img class="emoji" alt="$" src="$"></img>'
-            .replace("$", token[i].content)
-            .replace("$", EmojiPng("./" + markup + ".png"));
+        return '<img class="emoji" alt="' + token[i].content + '" src="' +
+            EmojiPng("./" + markup + ".png") + '"></img>';
     } else {
         return ":" + markup + ":";
     }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "less-loader": "^2.0.0",
     "lodash": "^3.7.0",
     "markdown-it": "^4.2.0",
-    "markdown-it-emoji": "^1.0.0",
+    "markdown-it-emoji": "markdown-it/markdown-it-emoji",
     "markdown-loader": "^0.1.2",
     "material-ui": "=0.7.3",
     "moment": "^2.10.2",


### PR DESCRIPTION
- As the title says: fix with `use(Emoji, {defs: emojifyDefs})`
- markdown-it-emoji _mater_ is more robust than _1.0_
- Regular expression problem
- undefined `this.props.onKeyDown` error
