### PR TITLE
upgrade dagre-d3 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "body-parser": "^1.9.3",
     "css-loader": "^0.9.0",
     "d3": "^3.5.5",
-    "dagre-d3": "^0.4.7",
+    "dagre-d3": "^0.4.13",
     "emojify.js": "=1.0.1",
     "enum": "2.1.0",
     "express": "^4.7.2",


### PR DESCRIPTION
to fix `Uncaught TypeError: e.getTransformToElement is not a function` in chrome 48

[dagre-d3 issue about this](https://github.com/cpettitt/dagre-d3/issues/202)
